### PR TITLE
Locate full databag over multiple keystone units

### DIFF
--- a/src/keystone_credentials.py
+++ b/src/keystone_credentials.py
@@ -80,8 +80,10 @@ class KeystoneCredentialsRequires(ops.Object):
     @cached_property
     def _raw_data(self) -> Optional[ops.RelationData]:
         if self.relation and self.relation.units:
-            first = list(self.relation.units)[0]
-            return self.relation.data[first]
+            data = {}
+            for unit in self.relation.units:
+                data.update(self.relation.data[unit])
+            return data
         return None
 
     @cached_property


### PR DESCRIPTION
## Overview

When related to multiple keystone units over a relation, ensure we don't just look on the first unit as it may not be the leader, and cannot provide connection details

## Details

juju relation data is uniquely transmitted from each keystone unit. It seems that when keystone is in HA mode, only the leader responds to the request for credentials.  We can't be assured that the leader keystone's databag is always is the first unit.  Therefore, we've got to look across all keystone units to collect the correct databag. 

thanks to @ggouzi for spotting this