### PR TITLE
Rollout restart the resources after applied changes

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -44,6 +44,13 @@ bases:
 
 config:
   options:
+    extra-args:
+      type: string
+      description: |
+        (Optional) Extra arguments to pass to the k8s-keystone-auth deployment.
+        Argument string will be split by shlex rules
+        For example: `juju config keystone-k8s-auth extra-args='--debug'`
+
     keystone-ssl-ca:
       type: string
       description: |

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -222,7 +222,7 @@ class ProviderManifests(Manifests):
 
     def restart(self, obj: HashableResource):
         """Restart the hashable object if its possible to do so."""
-        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
         T = type(obj.resource)
         patch = obj.resource
         try:

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -9,7 +9,7 @@ import pickle
 import shlex
 import ssl
 from hashlib import md5
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from lightkube.codecs import AnyResource
 from lightkube.models.apps_v1 import Deployment
@@ -81,14 +81,14 @@ class UpdateDeployment(Patch):
         server_url: str = self.manifests.config.get("keystone-url", "")
         ca_cert: str = self.manifests.config.get("keystone-ssl-ca")
         replicas: int = self.manifests.config.get("replicas", 2)
-        extra_args: str = shlex.split(self.manifests.config.get("extra-args", ""))
+        extra_args: List[str] = shlex.split(self.manifests.config.get("extra-args", ""))
 
         log.info("Patching server_url for %s/%s", obj.kind, obj.metadata.name)
         obj.spec.replicas = replicas
         obj.spec.template.metadata.annotations = {}
         for container in obj.spec.template.spec.containers:
             if container.name == RESOURCE_NAME:
-                container.args += extra_args
+                container.args = container.args[:1] + extra_args
                 for env in container.env:
                     if env.name == "OS_AUTH_URL":
                         env.value = server_url

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -67,11 +67,10 @@ class UpdateDeployment(Patch):
 
     REQUIRED_CONFIG = {"keystone-url"}
 
-    def __call__(self, obj):
+    def __call__(self, obj: AnyResource):
         """Patch the k8s-keyston-auth deployment."""
-        if not (obj.kind == "Deployment" and obj.metadata.name == RESOURCE_NAME):
+        if not (isinstance(obj, Deployment) and obj.metadata.name == RESOURCE_NAME):
             return
-        obj: Deployment = obj
 
         for volume in obj.spec.template.spec.volumes:
             if volume.secret:


### PR DESCRIPTION
## Overview

When config or relation data causes changes need to be applied such as certificate changes or version changes, be sure to rollout restart the deployment AFTER the installation is complete so that the new changes are picked up. 

## Details
* the keystone-k8s-auth deployment isn't so good about restarting the webservice on changes to the certificate data.  It can handle changes to the configmap well enough, but its safer to just rollout new pods when these changes in config occur.  
* Add a new config option called `extra-args` allowing the juju admin to suppress or increase verbosity on the service.