### PR TITLE
feat: migrate from `rocks.c.c` to `ghcr.io`

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -92,7 +92,7 @@ config:
         If unset, the manifests will use the image registry from the kube-control relation
 
         example)
-          juju config keystone-k8s-auth image-registry='rocks.canonical.com:443/cdk'
+          juju config keystone-k8s-auth image-registry='ghcr.io/canonical/cdk'
           juju config keystone-k8s-auth --reset image-registry
     release:
       type: string

--- a/tests/data/kube_control_data.yaml
+++ b/tests/data/kube_control_data.yaml
@@ -27,7 +27,7 @@ has-xcp: "false"
 ingress-address: 10.246.154.7
 port: "53"
 private-address: 10.246.154.7
-registry-location: rocks.canonical.com:443/cdk
+registry-location: ghcr.io/canonical/cdk
 sdn-ip: 10.152.183.20
 taints: '["node-role.kubernetes.io/control-plane=true:NoSchedule"]'
 labels: '["node-role.kubernetes.io/control-plane=true"]'

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -67,7 +67,7 @@ def kube_control():
     with mock.patch("charm.KubeControlRequirer") as mocked:
         kube_control = mocked.return_value
         kube_control.evaluate_relation.return_value = None
-        kube_control.get_registry_location.return_value = "rocks.canonical.com/cdk"
+        kube_control.get_registry_location.return_value = "ghcr.io/canonical/cdk"
         kube_control.get_controller_taints.return_value = []
         kube_control.get_controller_labels.return_value = []
         kube_control.relation.app.name = "kubernetes-control-plane"

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
         --cov-report=html \
         --ignore={[vars]tst_path}integration \
         -vv --tb native -s \
-        {posargs:[vars]tst_path}unit}
+        {posargs:{[vars]tst_path}unit}
 
 [testenv:integration]
 description = Run integration tests

--- a/upstream/update.py
+++ b/upstream/update.py
@@ -26,7 +26,7 @@ logging.basicConfig(level=logging.INFO)
 GH_REPO = "https://github.com/{repo}"
 GH_TAGS = "https://api.github.com/repos/{repo}/tags"
 GH_RAW = "https://raw.githubusercontent.com/{repo}/{rel}/{path}/{manifest}"
-ROCKS_CC = "upload.rocks.canonical.com:5000/cdk"
+GHCR_CDK = "ghcr.io/canonical/cdk"
 
 SOURCES = dict(
     keystone_auth=dict(
@@ -289,7 +289,7 @@ def get_argparser():
     )
     parser.add_argument(
         "--registry",
-        default=ROCKS_CC,
+        default=GHCR_CDK,
         type=str,
         help="Registry to which images should be mirrored.\n\n"
         "example\n"


### PR DESCRIPTION
## Overview

Migrate the registry from `rocks.canonical.com` to `ghcr.io`.